### PR TITLE
Change icons

### DIFF
--- a/desktop/src/main/java/bisq/desktop/bisq.css
+++ b/desktop/src/main/java/bisq/desktop/bisq.css
@@ -130,6 +130,9 @@ bg color of non edit textFields: fafafa
     -bs-rd-error-red: #dd0000; /* 5 usages */
     -bs-rd-message-bubble: #0086C6;
     -bs-toggle-selected: #7B7B7B;
+    -bs-level-bronze: #CD7F32;
+    -bs-level-silver: #A9A9A9;
+    -bs-level-gold: #DAA520;
 
     -bs-red: #D73030; /* 5 usages */
     -fx-box-border: -bs-rd-grey-medium-light;
@@ -198,15 +201,18 @@ bg color of non edit textFields: fafafa
 }
 
 .score-gold {
-    -fx-text-fill: #ffde5d;
+    -fx-fill: -bs-level-gold;
+    -fx-opacity: 1;
 }
 
 .score-silver {
-    -fx-text-fill: #d2d0d1;
+    -fx-fill: -bs-level-silver;
+    -fx-opacity: 1;
 }
 
 .score-bronze {
-    -fx-text-fill: #8f7837;
+    -fx-fill: -bs-level-bronze;
+    -fx-opacity: 1;
 }
 
 .delay-label {

--- a/desktop/src/main/java/bisq/desktop/components/PeerInfoIcon.java
+++ b/desktop/src/main/java/bisq/desktop/components/PeerInfoIcon.java
@@ -38,8 +38,7 @@ import bisq.common.util.Utilities;
 
 import com.google.common.base.Charsets;
 
-import de.jensd.fx.fontawesome.AwesomeDude;
-import de.jensd.fx.fontawesome.AwesomeIcon;
+import de.jensd.fx.glyphs.materialdesignicons.MaterialDesignIcon;
 
 import javafx.scene.Group;
 import javafx.scene.canvas.Canvas;
@@ -62,6 +61,8 @@ import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
 
+import static bisq.desktop.util.FormBuilder.getBigIconForLabel;
+import static bisq.desktop.util.FormBuilder.getIconForLabel;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 @Slf4j
@@ -80,7 +81,7 @@ public class PeerInfoIcon extends Group {
     protected final Pane numTradesPane;
     private final String fullAddress;
     private final double scaleFactor;
-    private final Label delayLabel, categoryIcon, delayIcon, signIcon;
+    private final Label delayLabel, accountLevelIcon, delayIcon, signIcon;
     private final BSFormatter formatter;
     private String tooltipText;
 
@@ -286,22 +287,20 @@ public class PeerInfoIcon extends Group {
         tagPane.getChildren().addAll(tagCircle, tagLabel);
 
         //TODO just dummy impl.
-        categoryIcon = new Label();
-        categoryIcon.setLayoutX(-20);
-        categoryIcon.setLayoutY(5);
-        categoryIcon.setVisible(false);
-        categoryIcon.setManaged(false);
+        accountLevelIcon = new Label();
+        accountLevelIcon.setLayoutX(-30);
+        accountLevelIcon.setVisible(false);
+        accountLevelIcon.setManaged(false);
 
         delayIcon = new Label();
-        AwesomeDude.setIcon(delayIcon, AwesomeIcon.TIME);
-        delayIcon.setLayoutX(-40);
-        delayIcon.setLayoutY(5);
+        getIconForLabel(MaterialDesignIcon.CLOCK_FAST, delayIcon);
+        delayIcon.setLayoutX(-50);
         delayIcon.setVisible(false);
         delayIcon.setManaged(false);
 
         delayLabel = new Label();
-        delayLabel.setLayoutX(-53);
-        delayLabel.setLayoutY(20);
+        delayLabel.setLayoutX(-63);
+        delayLabel.setLayoutY(15);
         delayLabel.setMinWidth(40);
         delayLabel.setMaxWidth(40);
         delayLabel.getStyleClass().add("delay-label");
@@ -309,13 +308,12 @@ public class PeerInfoIcon extends Group {
         delayLabel.setManaged(false);
 
         signIcon = new Label();
-        AwesomeDude.setIcon(signIcon, AwesomeIcon.SHIELD);
-        signIcon.setLayoutX(-60);
-        signIcon.setLayoutY(5);
+        getIconForLabel(MaterialDesignIcon.APPROVAL, signIcon);
+        signIcon.setLayoutX(-70);
         signIcon.setVisible(false);
         signIcon.setManaged(false);
 
-        getChildren().addAll(outerBackground, innerBackground, avatarImageView, tagPane, numTradesPane, categoryIcon, delayIcon, delayLabel, signIcon);
+        getChildren().addAll(outerBackground, innerBackground, avatarImageView, tagPane, numTradesPane, accountLevelIcon, delayIcon, delayLabel, signIcon);
 
         addMouseListener(numTrades, privateNotificationManager, offer, preferences, formatter, useDevPrivilegeKeys, isFiatCurrency, peersAccountAge);
 
@@ -398,8 +396,8 @@ public class PeerInfoIcon extends Group {
                 optionalScoreInfo = accountScoreService.getScoreInfoForBuyer(trade);
             }
             boolean isScoreInfoPresent = optionalScoreInfo.isPresent();
-            categoryIcon.setVisible(isScoreInfoPresent);
-            categoryIcon.setManaged(isScoreInfoPresent);
+            accountLevelIcon.setVisible(isScoreInfoPresent);
+            accountLevelIcon.setManaged(isScoreInfoPresent);
             delayIcon.setVisible(isScoreInfoPresent);
             delayIcon.setManaged(isScoreInfoPresent);
             signIcon.setVisible(isScoreInfoPresent);
@@ -423,14 +421,14 @@ public class PeerInfoIcon extends Group {
                 delayLabel.setManaged(requireDelay);
 
                 if (scoreInfo.getAccountScoreCategory() == AccountScoreCategory.GOLD) {
-                    categoryIcon.getStyleClass().addAll("score-gold");
-                    AwesomeDude.setIcon(categoryIcon, AwesomeIcon.STAR);
+                    getBigIconForLabel(MaterialDesignIcon.SHIELD, accountLevelIcon)
+                            .getStyleClass().add("score-gold");
                 } else if (scoreInfo.getAccountScoreCategory() == AccountScoreCategory.SILVER) {
-                    categoryIcon.getStyleClass().addAll("score-silver");
-                    AwesomeDude.setIcon(categoryIcon, AwesomeIcon.STAR_HALF_EMPTY);
+                    getBigIconForLabel(MaterialDesignIcon.SHIELD_HALF_FULL, accountLevelIcon)
+                            .getStyleClass().add("score-silver");
                 } else if (scoreInfo.getAccountScoreCategory() == AccountScoreCategory.BRONZE) {
-                    categoryIcon.getStyleClass().addAll("score-bronze");
-                    AwesomeDude.setIcon(categoryIcon, AwesomeIcon.STAR_EMPTY);
+                    getBigIconForLabel(MaterialDesignIcon.SHIELD_OUTLINE, accountLevelIcon)
+                            .getStyleClass().add("score-bronze");
                 }
             }
         }

--- a/desktop/src/main/java/bisq/desktop/util/FormBuilder.java
+++ b/desktop/src/main/java/bisq/desktop/util/FormBuilder.java
@@ -1710,6 +1710,14 @@ public class FormBuilder {
         }
     }
 
+    public static Text getIconForLabel(GlyphIcons icon, Label label) {
+        return getIconForLabel(icon, "1.231em", label);
+    }
+
+    public static Text getBigIconForLabel(GlyphIcons icon, Label label) {
+        return getIconForLabel(icon, "2em", label);
+    }
+
     public static Text getSmallIconForLabel(GlyphIcons icon, Label label) {
         return getIconForLabel(icon, "0.769em", label);
     }

--- a/monitor/src/main/java/bisq/monitor/metric/P2PNetworkLoad.java
+++ b/monitor/src/main/java/bisq/monitor/metric/P2PNetworkLoad.java
@@ -17,36 +17,19 @@
 
 package bisq.monitor.metric;
 
-import java.io.File;
+import bisq.monitor.AvailableTor;
+import bisq.monitor.Metric;
+import bisq.monitor.Monitor;
+import bisq.monitor.Reporter;
+import bisq.monitor.ThreadGate;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-
-import org.springframework.core.env.PropertySource;
-
-import bisq.common.Clock;
-import bisq.common.app.Capabilities;
-import bisq.common.app.Capability;
-import bisq.common.proto.network.NetworkEnvelope;
-import bisq.common.proto.network.NetworkProtoResolver;
 import bisq.core.app.BisqEnvironment;
 import bisq.core.btc.BaseCurrencyNetwork;
 import bisq.core.btc.BtcOptionKeys;
 import bisq.core.network.p2p.seed.DefaultSeedNodeRepository;
 import bisq.core.proto.network.CoreNetworkProtoResolver;
 import bisq.core.proto.persistable.CorePersistenceProtoResolver;
-import bisq.monitor.AvailableTor;
-import bisq.monitor.Metric;
-import bisq.monitor.Monitor;
-import bisq.monitor.Reporter;
-import bisq.monitor.ThreadGate;
+
 import bisq.network.p2p.network.Connection;
 import bisq.network.p2p.network.MessageListener;
 import bisq.network.p2p.network.NetworkNode;
@@ -56,6 +39,26 @@ import bisq.network.p2p.peers.PeerManager;
 import bisq.network.p2p.peers.keepalive.KeepAliveManager;
 import bisq.network.p2p.peers.peerexchange.PeerExchangeManager;
 import bisq.network.p2p.storage.messages.BroadcastMessage;
+
+import bisq.common.Clock;
+import bisq.common.app.Capabilities;
+import bisq.common.app.Capability;
+import bisq.common.proto.network.NetworkEnvelope;
+import bisq.common.proto.network.NetworkProtoResolver;
+
+import org.springframework.core.env.PropertySource;
+
+import java.io.File;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -172,7 +175,7 @@ public class P2PNetworkLoad extends Metric implements MessageListener, SetupList
                 });
                 int maxConnections = Integer.parseInt(configuration.getProperty(MAX_CONNECTIONS, "12"));
                 NetworkProtoResolver networkProtoResolver = new CoreNetworkProtoResolver();
-                CorePersistenceProtoResolver persistenceProtoResolver = new CorePersistenceProtoResolver(null,
+                CorePersistenceProtoResolver persistenceProtoResolver = new CorePersistenceProtoResolver(null, null,
                         networkProtoResolver, storageDir);
                 DefaultSeedNodeRepository seedNodeRepository = new DefaultSeedNodeRepository(environment, null);
                 PeerManager peerManager = new PeerManager(networkNode, seedNodeRepository, new Clock(),


### PR DESCRIPTION
I changed the account level icon to shield (empty, half, full) as I think this gets less confused as the star (rating, mark favorite). I also increased the size of it to make it easier to recognize and as it is more a grouping icon for the additional information icons (delay, can sign).  I also went for a slightly changed clock icon (less bold with movement indication). Although we don't want to give the false impression what attestation means for us, I think using a shield is not intuitive. I think an icon with a checkmark would work better for this use-case.
![Bildschirmfoto 2019-05-01 um 09 50 19](https://user-images.githubusercontent.com/170962/57009469-18485b00-6bf7-11e9-9cef-86ad60426085.png)
